### PR TITLE
Add plugin info toggle to help menu and restore premium emoji mapping

### DIFF
--- a/utils/emoji.py
+++ b/utils/emoji.py
@@ -1,7 +1,7 @@
 """Utility helpers for premium emoji conversion."""
 
-from typing import Dict, List, Optional, Tuple
 import re
+from typing import Dict, List, Optional, Tuple
 
 from telethon.tl.types import (
     MessageEntityCustomEmoji,


### PR DESCRIPTION
## Summary
- add an inline toggle in the help menu to show plugin metadata
- implement a plugin info view with callbacks for returning to the main help categories
- ensure the premium emoji mapping utilities load by importing the required typing symbols

## Testing
- python -m compileall plugins/help.py utils/emoji.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e712e6788324810445b470b84de6