### PR TITLE
Route .help command via inline assistant

### DIFF
--- a/ASSISTANT_BOT_QUICKSTART.md
+++ b/ASSISTANT_BOT_QUICKSTART.md
@@ -20,6 +20,7 @@ Update `.env` dengan token assistant bot:
 ```env
 ASSISTANT_BOT_TOKEN=8314911312:AAEZTrlru95_QNycAt4TlYH_k-7q2f_PQ9c
 OWNER_ID=7553981355
+ASSISTANT_BOT_USERNAME=VzAssistantBot
 ```
 
 ### 3. Run Assistant Bot
@@ -60,13 +61,13 @@ screen -dmS assistant python3 assistant_bot_pyrogram.py
 ### Test Inline Keyboards
 1. Start bot: `python3 assistant_bot_pyrogram.py`
 2. Open Telegram dan chat dengan bot
-3. Kirim `/help`
+3. Kirim `/help` *(atau jalankan `.help` di userbot untuk membuka inline browser)*
 4. Click category buttons untuk navigate
 5. Test `/alive` untuk debug
 
 ### Debug Commands
 Bot ini dibuat khusus untuk debug:
-- `.help` - debug help menu
+- `.help` - inline help menu (dipicu dari userbot & bot)
 - `.alive` - debug alive message
 - `.joinvc` - debug voice chat
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -240,6 +240,7 @@ databases/
 - [ ] Sudoers get triggered by developer's PM permit
 
 #### 3.11 HELP (.help)
+- [x] Userbot `.help` membuka inline browser via assistant bot (fallback otomatis bila offline)
 - [ ] Inline button interface
 - [ ] List all plugins + functions
 - [ ] Hide developer-only plugins for sudoers

--- a/config.py
+++ b/config.py
@@ -37,6 +37,9 @@ FOUNDER_USERNAME = "@VZLfxs"
 FOUNDER_LINK = "t.me/VZLfxs"
 BRANDING_FOOTER = "2025© Vzoel Fox's Lutpan"
 
+# Assistant bot bridge
+ASSISTANT_BOT_USERNAME = os.getenv("ASSISTANT_BOT_USERNAME")
+
 # Deploy Bot Configuration
 DEPLOY_BOT_USERNAME = os.getenv("DEPLOY_BOT_USERNAME", "@VZDeployBot")  # Set in .env
 


### PR DESCRIPTION
## Summary
- update the userbot `.help` handler to open the assistant bot inline browser with a graceful static fallback
- add shared help text builders and inline query support to the assistant bot to preserve the paginated workflow
- document the new `ASSISTANT_BOT_USERNAME` setting and describe the inline help experience in the quickstart and roadmap

## Testing
- python -m compileall plugins/help.py
- python -m compileall assistant_bot_pyrogram.py

------
https://chatgpt.com/codex/tasks/task_e_68e297d9d5a88324960d94c5f966c858